### PR TITLE
Remove comment that confused less-to-sass

### DIFF
--- a/less/_variables.less
+++ b/less/_variables.less
@@ -152,7 +152,7 @@
 @mdb-btn-font-size-xs: 10px;
 
 
-@mdb-btn-background-color: @body-bg; //transparent;
+@mdb-btn-background-color: @body-bg;
 @mdb-btn-background-color-text: @mdb-text-color-primary;
 
 


### PR DESCRIPTION
I was trying to customize the default button color with the `$mdb-btn-background-color` variable (in SASS) without any luck. It turns out that the `!default` flag necessary to override a variable was missing from the generated SASS.

Here is the source LESS:

``` less
@mdb-btn-background-color: @body-bg; //transparent;
```

And the resulting SASS:

``` sass
$mdb-btn-background-color: $body-bg; //transparent !default;
```

The SASS should instead look like:

``` sass
$mdb-btn-background-color: $body-bg !default; //transparent
```

Grunt-less-to-sass was adding the default! flag to the comment at the end of the line instead of at the correct position. The offending regex can be seen here: https://github.com/duvillierA/grunt-less-to-sass/blob/master/tasks/lib/replacements/default.js

The longer-term solution is to fix less-to-sass; removing the comment is enough to fix things on our end.
